### PR TITLE
Relax package versions and make test DB URI more dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .cache
 .tox
 docs/build
+htmlcov

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+Version 0.1.2
+-------------
+
+Released 2016-10-19
+
+* Relaxed package versions so that they are not pinned down unless it is necessary.
+* Stopped using static YAML files to set test parameters and started using pytest parser instead.
+* Makefile added.
+* CHANGELOG added.
+* README documentation updated.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: test
+
+HTMLCOV_DIR ?= htmlcov
+
+test: flake8 test_lib
+
+flake8:
+	flake8 sqlalchemydiff test
+
+test_lib:
+	coverage run --source=sqlalchemydiff -m pytest test $(ARGS)
+
+coverage-html: test
+	coverage html -d $(HTMLCOV_DIR)
+
+coverage-report: test
+	coverage report -m
+
+coverage: coverage-html coverage-report test

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,28 @@ SQLAlchemy Diff
     inspection API.
 
 
+Running tests
+-------------
+
+Makefile targets that can be used to run the tests.
+
+Test databases will be created, used during the tests and destroyed afterwards.
+
+Example of usage:
+
+.. code-block:: shell
+
+    $ # using default settings
+    $ pytest test
+    $ make test
+    $ make coverage
+
+    $ # or overridding the database URI
+    $ pytest test --test-db-url=mysql+mysqlconnector://root:password@localhost:3306/sqlalchemydiff
+    $ make test ARGS="--test-db-url=mysql+mysqlconnector://root:password@localhost:3306/sqlalchemydiff"
+    $ make coverage ARGS="--lf -x -vv --test-db-url=mysql+mysqlconnector://root:password@localhost:3306/sqlalchemydiff"
+
+
 License
 -------
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,2 +1,0 @@
-DB_URIS:
-    "test": "mysql+mysqlconnector://root:password@dockermachine:3306/sqlalchemydiff"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as stream:
 
 setup(
     name='sqlalchemy-diff',
-    version='0.1.1',
+    version='0.1.2',
     description='Compare two database schemas using sqlalchemy.',
     long_description=readme,
     author='student.com',
@@ -21,15 +21,16 @@ setup(
     url='https://github.com/Overseas-Student-Living/sqlalchemy-diff',
     packages=find_packages(exclude=['docs', 'test', 'test.*']),
     install_requires=[
-        "six==1.10.0",
-        "mock>=2.0.0",
-        "sqlalchemy-utils==0.32.4",
-        "pyyaml>=3.11",
+        "six>=1.10.0",
+        "sqlalchemy-utils>=0.32.4",
     ],
     extras_require={
         'dev': [
+            "mock==2.0.0",
             "mysql-connector-python==2.0.4",
-            "pytest==2.9.1",
+            "pytest==3.0.3",
+            "flake8==3.0.4",
+            "coverage==4.2",
         ],
         'docs': [
             "sphinx==1.4.1",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,22 +1,23 @@
-import os
-
 import pytest
-import yaml
 
 
 @pytest.fixture(scope="session")
-def project_root():
-    return os.path.dirname(os.path.dirname(__file__))
+def db_uri(request):
+    return request.config.getoption('TEST_DB_URL')
 
 
-@pytest.fixture(scope="session")
-def test_config(project_root):
-    config_file = os.path.join(project_root, "config", "config.yaml")
-    with open(config_file) as stream:
-        config = yaml.load(stream.read())
-    return config
-
-
-@pytest.fixture(scope="session")
-def db_uri(test_config):
-    return test_config['DB_URIS']['test']
+def pytest_addoption(parser):
+    parser.addoption(
+        '--test-db-url',
+        action='store',
+        dest='TEST_DB_URL',
+        default=(
+            'mysql+mysqlconnector://root:password@localhost:3306/'
+            'sqlalchemydiff'
+        ),
+        help=(
+            'DB url for testing (e.g. '
+            '"mysql+mysqlconnector://root:password@localhost:3306/'
+            'sqlalchemydiff''")'
+        )
+    )


### PR DESCRIPTION
- Relaxed package versions so that they are not pinned down unless it is necessary.
- Stopped using static YAML files to set test parameters and started using pytest parser instead.
- Makefile added.
- CHANGELOG added.
- README documentation updated.