### PR TITLE
Add primary key constraint name comparison

### DIFF
--- a/sqlalchemydiff/comparer.py
+++ b/sqlalchemydiff/comparer.py
@@ -281,7 +281,8 @@ def _get_primary_keys_info(
     left_pk_constraint = _get_primary_keys(left_inspector, table_name)
     right_pk_constraint = _get_primary_keys(right_inspector, table_name)
 
-    pk_constraint_has_name = 'name' in left_pk_constraint
+    pk_constraint_has_name = ('name' in left_pk_constraint and
+                              left_pk_constraint['name'] is not None)
 
     if pk_constraint_has_name:
         left_pk = ({left_pk_constraint['name']: left_pk_constraint}

--- a/test/unit/test_comparer.py
+++ b/test/unit/test_comparer.py
@@ -431,8 +431,8 @@ class TestCompareInternals(object):
     def test__get_primary_keys_info(
             self, _diff_dicts_mock, _get_primary_keys_mock):
         _get_primary_keys_mock.side_effect = [
-            ['pk_left_1', 'pk_left_2'],
-            ['pk_right_1']
+            {'constrained_columns': ['pk_left_1', 'pk_left_2']},
+            {'constrained_columns': ['pk_right_1']}
         ]
         left_inspector, right_inspector = Mock(), Mock()
 
@@ -449,8 +449,8 @@ class TestCompareInternals(object):
     def test__get_primary_keys_info_ignores(
             self, _diff_dicts_mock, _get_primary_keys_mock):
         _get_primary_keys_mock.side_effect = [
-            ['pk_left_1', 'pk_left_2'],
-            ['pk_right_1', 'pk_right_2']
+            {'constrained_columns': ['pk_left_1', 'pk_left_2']},
+            {'constrained_columns': ['pk_right_1', 'pk_right_2']},
         ]
         left_inspector, right_inspector = Mock(), Mock()
         ignores = ['pk_left_1', 'pk_right_2']
@@ -465,13 +465,58 @@ class TestCompareInternals(object):
 
         assert _diff_dicts_mock.return_value == result
 
+    def test__get_primary_keys_info_with_pk_constraint_name(
+            self, _diff_dicts_mock, _get_primary_keys_mock):
+        _get_primary_keys_mock.side_effect = [
+            {'name': 'left', 'constrained_columns': ['pk_left_1']},
+            {'name': 'right', 'constrained_columns': ['pk_right_1']}
+        ]
+        left_inspector, right_inspector = Mock(), Mock()
+
+        result = _get_primary_keys_info(
+            left_inspector, right_inspector, 'table_A', [])
+
+        _diff_dicts_mock.assert_called_once_with(
+            {
+                'left': {'name': 'left',
+                         'constrained_columns': ['pk_left_1']}
+            },
+            {
+                'right': {'name': 'right',
+                          'constrained_columns': ['pk_right_1']}
+            }
+        )
+        assert _diff_dicts_mock.return_value == result
+
+    def test__get_primary_keys_info_ignores_with_pk_constraint_name(
+            self, _diff_dicts_mock, _get_primary_keys_mock):
+        _get_primary_keys_mock.side_effect = [
+            {'name': 'left_1', 'constrained_columns': ['pk_left_1']},
+            {'name': 'right_1', 'constrained_columns': ['pk_right_1']},
+        ]
+        left_inspector, right_inspector = Mock(), Mock()
+        ignores = ['left_1', 'left_2', 'right_2']
+
+        result = _get_primary_keys_info(
+            left_inspector, right_inspector, 'table_A', ignores)
+
+        _diff_dicts_mock.assert_called_once_with(
+            dict(),
+            {
+                'right_1': {'name': 'right_1',
+                            'constrained_columns': ['pk_right_1']},
+            }
+        )
+
+        assert _diff_dicts_mock.return_value == result
+
     def test__get_primary_keys(self):
         inspector = Mock()
 
         result = _get_primary_keys(inspector, 'table_A')
 
-        inspector.get_primary_keys.assert_called_once_with('table_A')
-        assert inspector.get_primary_keys.return_value == result
+        inspector.get_pk_constraint.assert_called_once_with('table_A')
+        assert inspector.get_pk_constraint.return_value == result
 
     def test__get_indexes_info(
             self, _diff_dicts_mock, _get_indexes_mock):


### PR DESCRIPTION
Change usage of SQLAlchemy's `get_primary_keys` to `get_pk_constraint` which
returns a dict with `constrained_columns` containing the primary key
fields and optionally `name` with the name of the pk constraint.
Update `get_primary_keys_info` to compare the entire dicts and apply
ignores on the constraint name rather than the key names if a `name`
field exists. If `name` does not exist, the primary key columns are
compared instead.