### PR TITLE
Make `Comparer.is_match` property work ...

### DIFF
--- a/src/sqlalchemydiff/comparer.py
+++ b/src/sqlalchemydiff/comparer.py
@@ -57,7 +57,10 @@ class CompareResult:
     @property
     def is_match(self):
         """Tell if comparison was a match."""
-        return not self.errors
+        for _inspector, errors in self.errors.items():
+            if errors:
+                return False
+        return True
 
     def dump_result(self, filename):
         """Dump `result` dict to a file."""


### PR DESCRIPTION
... for an `errors` dictionary full of
inspectors without any errors, for example:

```
{
    'columns': {},
    'primary_keys': {},
    'foreign_keys': {},
    'indexes': {},
    'unique_constraints': {},
    'check_constraints': {},
}
```